### PR TITLE
feat: remote deployment with API auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,15 @@
+# Server
 PORT=8080
+
+# Database path (absolute path on server; default: ./usage.db)
+# DB_PATH=/opt/bitnami/apps/claude-usage/data/usage.db
+
+# Auth: API key for scraper POST requests (generate with: openssl rand -hex 32)
+SCRAPE_API_KEY=
+
+# Auth: Basic auth for /api/scrape/history
+HISTORY_USER=
+HISTORY_PASS=
+
+# CORS: comma-separated origins, or * for allow-all (default)
+# CORS_ORIGIN=https://brennan.games

--- a/capture/scrape-usage.js
+++ b/capture/scrape-usage.js
@@ -27,6 +27,7 @@ const jsonOutput = args.includes('--output=json');
 const saveToFile = args.includes('--save');
 const doPost = args.includes('--post') || args.some(a => a.startsWith('--post-url='));
 const postUrl = (args.find(a => a.startsWith('--post-url=')) || '').split('=')[1] || 'http://localhost:8080/api/scrape';
+const apiKey = (args.find(a => a.startsWith('--api-key=')) || '').split('=')[1] || process.env.SCRAPE_API_KEY || '';
 
 function log(...msg) {
   if (!jsonOutput) console.log(...msg);
@@ -166,9 +167,13 @@ async function main() {
   if (doPost) {
     log(`\nPOSTing data to ${postUrl}...`);
     const scrape_duration_ms = Date.now() - startMs;
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) {
+      headers['Authorization'] = `Bearer ${apiKey}`;
+    }
     const res = await fetch(postUrl, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify({ ...data, scrape_duration_ms }),
     });
     if (res.ok) {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# deploy.sh — Push code to Lightsail instance
+set -euo pipefail
+
+SERVER="${DEPLOY_HOST:-user@brennan.games}"
+REMOTE_DIR="${DEPLOY_DIR:-/opt/bitnami/apps/claude-usage}"
+
+echo "Syncing files to $SERVER:$REMOTE_DIR..."
+rsync -avz --exclude node_modules --exclude '*.db' --exclude .env \
+  --exclude capture/ --exclude .auth-state.json --exclude .claude/ \
+  --exclude test-results/ --exclude playwright-report/ \
+  . "$SERVER:$REMOTE_DIR/"
+
+echo "Installing dependencies..."
+ssh "$SERVER" "cd $REMOTE_DIR && npm install --production"
+
+echo "Restarting PM2 process..."
+ssh "$SERVER" "cd $REMOTE_DIR && pm2 restart claude-usage || pm2 start ecosystem.config.js"
+
+echo "Done. Health check:"
+curl -s "https://brennan.games/claudemd/usage/health" | jq .

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  apps: [{
+    name: 'claude-usage',
+    script: 'server/index.js',
+    instances: 1,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '300M',
+    env: {
+      NODE_ENV: 'production',
+      PORT: 8080,
+    },
+  }],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-max-usage-analytics",
-  "version": "1.01.0001",
+  "version": "1.01.0002",
   "description": "Dashboard that replicates claude.ai/settings/usage, powered by Playwright scraping.",
   "main": "server/index.js",
   "scripts": {

--- a/public/app.js
+++ b/public/app.js
@@ -170,7 +170,7 @@ async function scrapeNow() {
 // ── Main usage data load ──────────────────────────────────────────────────────
 async function loadData() {
   try {
-    const res = await fetch('/api/scrape/latest');
+    const res = await fetch('api/scrape/latest');
     const snapshot = await res.json();
 
     if (!snapshot || snapshot.data === null) {

--- a/server/db.js
+++ b/server/db.js
@@ -1,7 +1,7 @@
 const Database = require('better-sqlite3');
 const path = require('path');
 
-const DB_PATH = path.join(__dirname, '..', 'usage.db');
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, '..', 'usage.db');
 
 let db;
 

--- a/server/index.js
+++ b/server/index.js
@@ -6,14 +6,23 @@ const { initDb } = require('./db');
 const scrapeRoutes = require('./routes/scrape');
 
 const PORT = process.env.PORT || 8080;
+const CORS_ORIGIN = process.env.CORS_ORIGIN || '*';
 
 // Initialize database
 initDb();
 
 const app = express();
 
-app.use(cors());
+app.use(cors({
+  origin: CORS_ORIGIN === '*' ? true : CORS_ORIGIN.split(','),
+  methods: ['GET', 'POST'],
+}));
 app.use(express.json());
+
+// Health check
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', uptime: process.uptime() });
+});
 
 // Serve static dashboard files
 app.use(express.static(path.join(__dirname, '..', 'public')));

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,68 @@
+const crypto = require('crypto');
+
+/**
+ * Bearer token auth for the scraper POST endpoint.
+ * Reads SCRAPE_API_KEY from env.
+ */
+function requireApiKey(req, res, next) {
+  const expected = process.env.SCRAPE_API_KEY;
+  if (!expected) {
+    console.error('SCRAPE_API_KEY not set — rejecting POST request');
+    return res.status(500).json({ error: 'Server misconfigured' });
+  }
+
+  const header = req.headers.authorization || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : '';
+
+  if (!token || !timingSafeEqual(token, expected)) {
+    return res.status(401).json({ error: 'Invalid or missing API key' });
+  }
+
+  next();
+}
+
+/**
+ * HTTP Basic Auth for the history endpoint.
+ * Reads HISTORY_USER and HISTORY_PASS from env.
+ */
+function requireBasicAuth(req, res, next) {
+  const user = process.env.HISTORY_USER;
+  const pass = process.env.HISTORY_PASS;
+
+  if (!user || !pass) {
+    console.error('HISTORY_USER/HISTORY_PASS not set — rejecting history request');
+    return res.status(500).json({ error: 'Server misconfigured' });
+  }
+
+  const header = req.headers.authorization || '';
+  if (!header.startsWith('Basic ')) {
+    res.setHeader('WWW-Authenticate', 'Basic realm="Usage History"');
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const decoded = Buffer.from(header.slice(6), 'base64').toString();
+  const [givenUser, ...passParts] = decoded.split(':');
+  const givenPass = passParts.join(':');
+
+  if (!timingSafeEqual(givenUser, user) || !timingSafeEqual(givenPass, pass)) {
+    res.setHeader('WWW-Authenticate', 'Basic realm="Usage History"');
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  next();
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ */
+function timingSafeEqual(a, b) {
+  const bufA = Buffer.from(String(a));
+  const bufB = Buffer.from(String(b));
+  if (bufA.length !== bufB.length) {
+    crypto.timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+module.exports = { requireApiKey, requireBasicAuth };

--- a/server/routes/scrape.js
+++ b/server/routes/scrape.js
@@ -9,6 +9,7 @@ const {
   insertSnapshot, getLatestSnapshot, getSnapshots,
   insertScrapeLog, getRecentScrapeLog, getScheduleInfo,
 } = require('../db');
+const { requireApiKey, requireBasicAuth } = require('../middleware/auth');
 
 const router = express.Router();
 
@@ -16,7 +17,7 @@ const router = express.Router();
 let isScraping = false;
 
 // POST /api/scrape — receives JSON from scraper, validates, stores in SQLite
-router.post('/', (req, res) => {
+router.post('/', requireApiKey, (req, res) => {
   const data = req.body;
 
   if (!data || !data.timestamp) {
@@ -45,8 +46,8 @@ router.get('/latest', (req, res) => {
   res.json(snapshot);
 });
 
-// GET /api/scrape/history?from=&to=&limit= — paginated history
-router.get('/history', (req, res) => {
+// GET /api/scrape/history?from=&to=&limit= — paginated history (basic auth required)
+router.get('/history', requireBasicAuth, (req, res) => {
   const { from, to, limit } = req.query;
   const snapshots = getSnapshots({
     from: from || undefined,


### PR DESCRIPTION
## Summary
- Split architecture: Express server deploys to remote Lightsail, scraper stays local (needs real Chrome for Cloudflare)
- Bearer API key auth on POST `/api/scrape` — only local scraper can push data
- Basic auth on GET `/api/scrape/history` — protects historical data
- Dashboard + `/api/scrape/latest` remain public
- Configurable DB path, CORS, health check endpoint
- PM2 config + deploy script for Lightsail deployment
- Zero new npm dependencies (uses Node built-in `crypto.timingSafeEqual`)

## Test plan
- [x] POST without API key returns 401
- [x] POST with wrong key returns 401
- [x] POST with correct Bearer key stores snapshot (200)
- [x] GET /api/scrape/latest is publicly accessible
- [x] GET /api/scrape/history without auth returns 401
- [x] GET /api/scrape/history with wrong creds returns 401
- [x] GET /api/scrape/history with correct basic auth returns data
- [x] GET /health returns { status: ok }
- [ ] Deploy to Lightsail and verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)